### PR TITLE
Make the Header Only library a plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,76 @@
 # Runtime Skeletal Mesh Generator for UE4
 Helper to create a SkeletalMeshComponent in UE4 at runtime.
 
-This is a header only library that simplify the process of creating a `USkeletalMeshComponent`, with many surfaces, at runtime.
+This is a UE4 plugin that simplify the process of creating a `USkeletalMeshComponent`, with many surfaces, at runtime.
 You can just pass all the surfaces' data, this library will take care to correctly populate the UE4 buffers, needed to have a fully working `USkeletalMeshComponent`.
+
+## How to use it
+
+To use this library:
+1. Add this plugin inside the UE4 game plugins folder.
+2. Specify `RuntimeSkeletalMeshGenerator` as plugin on your `Game.uproject`, to enable it.
+3. Import the plugin using `#import "RuntimeSkeletalMeshGenerator/RuntimeSkeletalMeshGenerator.h"`
+
+The plugin is ready to be used, here an example on how to use it:
+```c++
+#import "RuntimeSkeletalMeshGenerator/RuntimeSkeletalMeshGenerator.h"
+
+void YourAmazingFunction()
+{
+	/// ----
+	/// Populates the passed `SkeletalMesh` with the passed surface data.
+	/// Make sure to pass a valid `USkeletalMesh`.
+	FRuntimeSkeletalMeshGenerator::GenerateSkeletalMesh(
+		SkeletalMesh,
+		Surfaces,
+		SurfacesMaterial,
+		BoneTransformsOverride);
+
+
+
+	/// ----
+	/// Creates a new `USkeletalMesh` and a new `USkeletalMeshComponent`.
+	/// It returns a valid `USkeletalMeshComponent`, with the generated `USkeletalMesh` assigned.
+	FRuntimeSkeletalMeshGenerator::GenerateSkeletalMeshComponent(
+		ActorOwner,
+		Skeleton,
+		Surfaces,
+		SurfacesMaterial,
+		BoneTransformsOverride);
+
+
+
+	/// ----
+	/// Creates a new `USkeletalMesh` and assign it to the given `SkeletalMeshComponent`.
+	FRuntimeSkeletalMeshGenerator::UpdateSkeletalMeshComponent(
+		SkeletalMeshComponent,
+		Skeleton,
+		Surfaces,
+		SurfacesMaterial,
+		BoneTransformsOverride);
+
+
+
+	/// ----
+	/// Decompose a `USkeletalMesh` to obtain the surfaces array.
+	/// This API can be thought as the complement of the above
+	/// three one, by submitting these arrays in one of the three
+	/// functions you would obtain a new `USkeletalMesh` that
+	/// would render the same mesh.
+
+	TArray<FMeshSurface> OutSurfaces;                  // The out Surfaces data that compose the `USkeletalMesh`.
+	TArray<int32> OutSurfacesVertexOffsets;            // The vertex offsets for each surface, relative to the passed `SkeletalMesh`: This is useful just in case you need to reconstruct the vertex index used on the `USkeletalMesh`.
+	TArray<int32> OutSurfacesIndexOffsets;             // The index offsets for each surface, relative to the passed `SkeletalMesh`: This is useful just in case you need to reconstruct the vertex index used on the `USkeletalMesh`.
+	TArray<UMaterialInterface*> OutSurfacesMaterial;   // The Materials used.
+	
+	FRuntimeSkeletalMeshGenerator::DecomposeSkeletalMesh(
+		SkeletalMesh,
+		TArray<FMeshSurface>& OutSurfaces,
+		TArray<int32>& OutSurfacesVertexOffsets,
+		TArray<int32>& OutSurfacesIndexOffsets,
+		TArray<UMaterialInterface*>& OutSurfacesMaterial);
+}
+```
 
 Authors:
 - https://github.com/RevoluPowered

--- a/RuntimeSkeletalMeshGenerator.uplugin
+++ b/RuntimeSkeletalMeshGenerator.uplugin
@@ -1,0 +1,24 @@
+{
+	"FileVersion": 3,
+	"Version": 1,
+	"VersionName": "1.0",
+	"FriendlyName": "RuntimeSkeletalMeshGenerator",
+	"Description": "",
+	"Category": "Other",
+	"CreatedBy": "IMVU Team - Andrea Catania, Gordon MacPherson",
+	"CreatedByURL": "",
+	"DocsURL": "",
+	"MarketplaceURL": "",
+	"SupportURL": "",
+	"CanContainContent": false,
+	"IsBetaVersion": false,
+	"IsExperimentalVersion": false,
+	"Installed": false,
+	"Modules": [
+		{
+			"Name": "RuntimeSkeletalMeshGenerator",
+			"Type": "Runtime",
+			"LoadingPhase": "PreEarlyLoadingScreen"
+		}
+	]
+}

--- a/Source/RuntimeSkeletalMeshGenerator/RuntimeSkeletalMeshGenerator.Build.cs
+++ b/Source/RuntimeSkeletalMeshGenerator/RuntimeSkeletalMeshGenerator.Build.cs
@@ -1,0 +1,19 @@
+using UnrealBuildTool;
+
+public class RuntimeSkeletalMeshGenerator : ModuleRules
+{
+	public RuntimeSkeletalMeshGenerator(ReadOnlyTargetRules Target) : base(Target)
+	{
+		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+
+		PrivateDependencyModuleNames.AddRange(
+			new string[]
+			{
+				"Core",
+				"CoreUObject",
+				"Engine",
+				"RenderCore",
+				"RHI",
+			});
+	}
+}

--- a/Source/RuntimeSkeletalMeshGenerator/RuntimeSkeletalMeshGenerator.cpp
+++ b/Source/RuntimeSkeletalMeshGenerator/RuntimeSkeletalMeshGenerator.cpp
@@ -10,47 +10,26 @@
 /* correctly populate the UE4 buffers, needed to have a fully working         */
 /* `USkeletalMeshComponent`.                                                  */
 /******************************************************************************/
-#pragma once
+#include "RuntimeSkeletalMeshGenerator.h"
 
-#include "Components/SkeletalMeshComponent.h"
-#include "Rendering/SkeletalMeshLODImporterData.h"
 #include "Rendering/SkeletalMeshLODModel.h"
-#include "Rendering/SkeletalMeshRenderData.h"
 #include "Rendering/SkeletalMeshModel.h"
 
-/**
- * Struct for BoneInfluences.
- */
-struct FRawBoneInfluence
+void FRuntimeSkeletalMeshGeneratorModule::StartupModule()
 {
-	float Weight;
-	int32 VertexIndex;
-	int32 BoneIndex;
-};
+}
 
-/**
- * This structure contains all the mesh surface info.
- */
-struct FMeshSurface
+void FRuntimeSkeletalMeshGeneratorModule::ShutdownModule()
 {
-	TArray<FVector> Vertices;
-	TArray<FVector> Tangents;
-	TArray<bool> FlipBinormalSigns;
-	TArray<FVector> Normals;
-	TArray<FColor> Colors;
-	TArray<TArray<FVector2D>> Uvs;
-	TArray<TArray<FRawBoneInfluence>> BoneInfluences;
-	TArray<uint32> Indices;
-};
+}
 
-/**
- * Generate the `SkeletalMesh` for the given surfaces.
- */
-inline void GenerateSkeletalMesh(
+IMPLEMENT_MODULE(FRuntimeSkeletalMeshGeneratorModule, RuntimeSkeletalMeshGenerator)
+
+void FRuntimeSkeletalMeshGenerator::GenerateSkeletalMesh(
 	USkeletalMesh* SkeletalMesh,
 	const TArray<FMeshSurface>& Surfaces,
 	const TArray<UMaterialInterface*>& SurfacesMaterial,
-	const TMap<FName, FTransform>& BoneTransformsOverride = TMap<FName, FTransform>())
+	const TMap<FName, FTransform>& BoneTransformsOverride)
 {
 	// Waits the rendering thread has done.
 	FlushRenderingCommands();
@@ -599,16 +578,12 @@ inline void GenerateSkeletalMesh(
 #endif
 }
 
-/**
- * Generate the `SkeletalMeshComponent` for the given surfaces, and add the
- * component to the `Actor`.
- */
-inline USkeletalMeshComponent* GenerateSkeletalMeshComponent(
+USkeletalMeshComponent* FRuntimeSkeletalMeshGenerator::GenerateSkeletalMeshComponent(
 	AActor* Actor,
 	USkeleton* BaseSkeleton,
 	const TArray<FMeshSurface>& Surfaces,
 	const TArray<UMaterialInterface*>& SurfacesMaterial,
-	const TMap<FName, FTransform>& BoneTransformsOverride = TMap<FName, FTransform>())
+	const TMap<FName, FTransform>& BoneTransformsOverride)
 {
 	// Note: we do not pass anything so the skeletal mesh is transient and
 	// destroyed when the play session end.
@@ -650,16 +625,12 @@ inline USkeletalMeshComponent* GenerateSkeletalMeshComponent(
 	return SkeletalMeshComponent;
 }
 
-/**
- * Update an existing the `SkeletalMeshComponent` for the given surfaces
- * optionally supply the transform override
- */
-inline void UpdateSkeletalMeshComponent(
+void FRuntimeSkeletalMeshGenerator::UpdateSkeletalMeshComponent(
 	USkeletalMeshComponent* SkeletalMeshComponent,
 	USkeleton* BaseSkeleton,
 	const TArray<FMeshSurface>& Surfaces,
 	const TArray<UMaterialInterface*>& SurfacesMaterial,
-	const TMap<FName, FTransform>& BoneTransformOverrides = TMap<FName, FTransform>())
+	const TMap<FName, FTransform>& BoneTransformOverrides)
 {
 	// Note: we do not pass anything so the skeletal mesh is transient and
 	// destroyed when the play session end.
@@ -681,8 +652,7 @@ inline void UpdateSkeletalMeshComponent(
 	check(SkeletalMeshComponent->FillComponentSpaceTransformsRequiredBones.Num() != 0);
 }
 
-/// Decompose the `USkeletalMesh` in `Surfaces`.
-inline bool DecomposeSkeletalMesh(
+bool FRuntimeSkeletalMeshGenerator::DecomposeSkeletalMesh(
 	/// The `SkeletalMesh` to decompose
 	const USkeletalMesh* SkeletalMesh,
 	/// Out Surfaces.

--- a/Source/RuntimeSkeletalMeshGenerator/RuntimeSkeletalMeshGenerator.h
+++ b/Source/RuntimeSkeletalMeshGenerator/RuntimeSkeletalMeshGenerator.h
@@ -1,0 +1,101 @@
+/******************************************************************************/
+/* SkeletalMeshComponent Generator for UE4.27                                 */
+/* -------------------------------------------------------------------------- */
+/* License MIT                                                                */
+/* Kindly sponsored by IMVU                                                   */
+/* -------------------------------------------------------------------------- */
+/* This is a header only library that simplify the process of creating a      */
+/* `USkeletalMeshComponent`, with many surfaces, at runtime.                  */
+/* You can just pass all the surfaces' data, this library will take care to   */
+/* correctly populate the UE4 buffers, needed to have a fully working         */
+/* `USkeletalMeshComponent`.                                                  */
+/******************************************************************************/
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Modules/ModuleManager.h"
+#include "Components/SkeletalMeshComponent.h"
+#include "Rendering/SkeletalMeshLODImporterData.h"
+#include "Rendering/SkeletalMeshRenderData.h"
+
+/**
+ * Struct for BoneInfluences.
+ */
+struct RUNTIMESKELETALMESHGENERATOR_API FRawBoneInfluence
+{
+	float Weight;
+	int32 VertexIndex;
+	int32 BoneIndex;
+};
+
+/**
+ * This structure contains all the mesh surface info.
+ */
+struct RUNTIMESKELETALMESHGENERATOR_API FMeshSurface
+{
+	TArray<FVector> Vertices;
+	TArray<FVector> Tangents;
+	TArray<bool> FlipBinormalSigns;
+	TArray<FVector> Normals;
+	TArray<FColor> Colors;
+	TArray<TArray<FVector2D>> Uvs;
+	TArray<TArray<FRawBoneInfluence>> BoneInfluences;
+	TArray<uint32> Indices;
+};
+
+class FRuntimeSkeletalMeshGeneratorModule : public IModuleInterface
+{
+public: // ------------------------------------- IModuleInterface implementation
+	virtual void StartupModule() override;
+	virtual void ShutdownModule() override;
+};
+
+class RUNTIMESKELETALMESHGENERATOR_API FRuntimeSkeletalMeshGenerator
+{
+public: // ----------------------------------------------------------------- API
+	/**
+	 * Generate the `SkeletalMesh` for the given surfaces.
+	 */
+	static void GenerateSkeletalMesh(
+		USkeletalMesh* SkeletalMesh,
+		const TArray<FMeshSurface>& Surfaces,
+		const TArray<UMaterialInterface*>& SurfacesMaterial,
+		const TMap<FName, FTransform>& BoneTransformsOverride = TMap<FName, FTransform>());
+
+	/**
+	 * Generate the `SkeletalMeshComponent` for the given surfaces, and add the
+	 * component to the `Actor`.
+	 */
+	static USkeletalMeshComponent* GenerateSkeletalMeshComponent(
+		AActor* Actor,
+		USkeleton* BaseSkeleton,
+		const TArray<FMeshSurface>& Surfaces,
+		const TArray<UMaterialInterface*>& SurfacesMaterial,
+		const TMap<FName, FTransform>& BoneTransformsOverride = TMap<FName, FTransform>());
+
+	/**
+	 * Update an existing the `SkeletalMeshComponent` for the given surfaces
+	 * optionally supply the transform override
+	 */
+	static void UpdateSkeletalMeshComponent(
+		USkeletalMeshComponent* SkeletalMeshComponent,
+		USkeleton* BaseSkeleton,
+		const TArray<FMeshSurface>& Surfaces,
+		const TArray<UMaterialInterface*>& SurfacesMaterial,
+		const TMap<FName, FTransform>& BoneTransformOverrides = TMap<FName, FTransform>());
+
+	/**
+	 * Decompose the `USkeletalMesh` in `Surfaces`.
+	 */
+	static bool DecomposeSkeletalMesh(
+		/// The `SkeletalMesh` to decompose
+		const USkeletalMesh* SkeletalMesh,
+		/// Out Surfaces.
+		TArray<FMeshSurface>& OutSurfaces,
+		/// The vertex offsets for each surface, relative to the passed `SkeletalMesh`
+		TArray<int32>& OutSurfacesVertexOffsets,
+		/// The index offsets for each surface, relative to the passed `SkeletalMesh`
+		TArray<int32>& OutSurfacesIndexOffsets,
+		/// Out Materials used.
+		TArray<UMaterialInterface*>& OutSurfacesMaterial);
+};


### PR DESCRIPTION
The rationale for this change is that this plugin may be used by many modules, and it's really bad include this file many time. Use a shared plugin is just convenient.